### PR TITLE
Add Docker support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -349,3 +349,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# Docker build directory
+build/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM mcr.microsoft.com/dotnet/sdk:6.0 as builder
+COPY ./ /src
+WORKDIR /src
+RUN dotnet restore && \
+    dotnet publish plex-credits-detect.sln -c Release -o build /p:CopyOutputSymbolsToPublishDirectory=false
+
+FROM mcr.microsoft.com/dotnet/runtime:6.0 AS runtime
+COPY --from=builder /src/build /app
+WORKDIR /app
+ENV DEBIAN_FRONTEND=noninteractive
+ENV XDG_CONFIG_HOME=/config
+RUN mkdir -p /config && \
+    chmod 777 /config && \
+    apt update && \
+    apt install -y ffmpeg && \
+    rm -rf /var/lib/apt/lists/*
+ENTRYPOINT ["dotnet", "plex-credits-detect.dll"]
+VOLUME [ "/config" ]

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
+    <IsPublishable>false</IsPublishable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Awesome project!

This adds a Dockerfile, enabling it to run as a docker container.

To build: `docker build --no-cache -t cjmanca/plex-credits-detect .`
To run: `docker run --rm -v /some/config/path:/config -it cjmanca/plex-credits-detect:latest`

Only tested on Linux, but should work anywhere Linux based Docker containers work.

If you want this to build using pipelines, that is also possible with a config similar to this one: https://github.com/drkno/PlexSSOv2/blob/master/.github/workflows/docker-publish.yml