### PR TITLE
Option to scan for cutoff unmet episodes

### DIFF
--- a/plex-credits-detect/Episode.cs
+++ b/plex-credits-detect/Episode.cs
@@ -188,6 +188,8 @@ namespace plexCreditsDetect
             path = Program.getRelativePath(path);
             Exists = false;
 
+            id = path;
+
             FileInfo fi;
 
             foreach (var bPath in Program.settings.paths)
@@ -210,7 +212,6 @@ namespace plexCreditsDetect
             fullPath = path;
             fullDirPath = Path.GetDirectoryName(path);
 
-            id = Program.getRelativePath(path);
             name = Path.GetFileName(path);
             dir = Program.getRelativeDirectory(path);
 

--- a/plex-credits-detect/Program.cs
+++ b/plex-credits-detect/Program.cs
@@ -55,12 +55,17 @@ namespace plexCreditsDetect
                 watchers[path].Filter = "*.*";
                 watchers[path].EnableRaisingEvents = true;
             }
-
-            foreach (var path in settings.paths)
-            {
-                scanner.CheckDirectory(path);
-            }
             */
+
+
+            if (settings.recheckUndetectedOnStartup)
+            {
+                Console.WriteLine("Crawling library paths to find episodes that don't meet the desired credit and intro numbers");
+                foreach (var path in settings.paths)
+                {
+                    scanner.CheckDirectory(path.Key);
+                }
+            }
 
 
             Console.WriteLine($"\nSyncing newly added episodes from plex...\n");
@@ -82,6 +87,7 @@ namespace plexCreditsDetect
 
                 if (dirs != null)
                 {
+                    dirs.Sort();
                     foreach (var item in dirs)
                     {
                         count++;

--- a/plex-credits-detect/resources/fingerprint.ini
+++ b/plex-credits-detect/resources/fingerprint.ini
@@ -32,4 +32,5 @@ videoAccuracy = 2
 videoSizeDivisor = 50
 frameRate = 1
 
+recheckUndetectedOnStartup = false
 forceRedetect = false

--- a/plex-credits-detect/settings.cs
+++ b/plex-credits-detect/settings.cs
@@ -52,6 +52,7 @@ namespace plexCreditsDetect
         public double videoSizeDivisor = 50;
         public int frameRate = 1;
 
+        public bool recheckUndetectedOnStartup = false;
         public bool forceRedetect = false;
 
         public Func<string, string> pathOverride = null;
@@ -96,6 +97,7 @@ namespace plexCreditsDetect
             ret.videoSizeDivisor = videoSizeDivisor;
             ret.frameRate = frameRate;
 
+            ret.recheckUndetectedOnStartup = recheckUndetectedOnStartup;
             ret.forceRedetect = forceRedetect;
 
             return ret;
@@ -159,6 +161,7 @@ namespace plexCreditsDetect
             TryGet(data, "default", "videoSizeDivisor", ref videoSizeDivisor);
             TryGet(data, "default", "frameRate", ref frameRate);
 
+            TryGet(data, "default", "recheckUndetectedOnStartup", ref recheckUndetectedOnStartup);
             TryGet(data, "default", "forceRedetect", ref forceRedetect);
 
             if (data.Sections.ContainsSection("directories"))


### PR DESCRIPTION
Adds a new option "recheckUndetectedOnStartup" to scan for cutoff unmet episodes.
Also now sorts lists by name before processing